### PR TITLE
验证码校验即销毁

### DIFF
--- a/kaptcha-spring-boot-starter/src/main/java/com/ryanbing/kaptcha/spring/boot/SessionKaptcha.java
+++ b/kaptcha-spring-boot-starter/src/main/java/com/ryanbing/kaptcha/spring/boot/SessionKaptcha.java
@@ -106,6 +106,7 @@ public class SessionKaptcha implements KaptchaAdapter {
 
         String sessionValue = (String) SessionUtil.getSessionAttribute(request, this.sessionKeyValue);
         Long sessionDataValue = (Long) SessionUtil.getSessionAttribute(request, this.sessionKeyDateValue);
+        request.getSession().setAttribute(this.sessionKeyDateValue, 0L);
 
         if (StringUtils.isEmpty(sessionDataValue)) {
             return false;


### PR DESCRIPTION
用户在使用该组件时，若在完成验证码校验后未及时销毁验证码而是交由前端刷新验证码，会造成暴力破解安全问题。
因此在组件层面校验验证码即刻令历史验证码过期。